### PR TITLE
Users can now choose location to export SDF to

### DIFF
--- a/ab_plugin_scenariolink/layouts/tabs/right.py
+++ b/ab_plugin_scenariolink/layouts/tabs/right.py
@@ -53,15 +53,20 @@ class RightTab(PluginTab):
         self.setLayout(self.layout)
 
     def record_selected(self, state):
+        """A record was selected by user, show the scenario chooser."""
         self.scenario_chooser.setVisible(state)
 
-    def generate_database(self, include_scenarios, dependencies, as_superstructure, superstructure_db_name):
+    def generate_database(self, include_scenarios, dependencies, as_superstructure,
+                          superstructure_db_name, superstructure_sdf_location):
+        """Start the database generation with the selected scenarios & SDF info."""
         if self.fold_chooser.use_table:
             record = self.fold_chooser.folds_table.model.selected_record
 
         # generate
         QtWidgets.QApplication.setOverrideCursor(Qt.WaitCursor)
-        unfold_databases(record, include_scenarios, dependencies, as_superstructure, superstructure_db_name)
+        unfold_databases(record, include_scenarios, dependencies, as_superstructure,
+                         superstructure_db_name, superstructure_sdf_location)
+        # update AB databases table
         ab_signals.databases_changed.emit()
         QtWidgets.QApplication.restoreOverrideCursor()
 
@@ -134,6 +139,7 @@ class ScenarioChooserWidget(QtWidgets.QWidget):
         super(ScenarioChooserWidget, self).__init__()
 
         self.layout = QtWidgets.QVBoxLayout()
+        self.sdf_path = None
 
         # Label
         self.label = QtWidgets.QLabel('Choose the scenarios you want to install')
@@ -150,13 +156,18 @@ class ScenarioChooserWidget(QtWidgets.QWidget):
         self.sdf_name_field = QtWidgets.QLineEdit()
         self.sdf_name_field.setPlaceholderText('Superstructure database name (optional)')
         self.sdf_name_field.setEnabled(False)
+        self.sdf_file_loc = QtWidgets.QPushButton('SDF location')
+        self.sdf_file_loc.setToolTip('Choose a folder to export the SDF scenario file to')
+        self.sdf_file_loc.setEnabled(False)
+
         self.sdf_layout = QtWidgets.QHBoxLayout()
         self.sdf_layout.addWidget(self.sdf_check)
         self.sdf_layout.addWidget(self.sdf_name_field)
+        self.sdf_layout.addWidget(self.sdf_file_loc)
         self.sdf_layout.addStretch()
         self.sdf_widget = QtWidgets.QWidget()
         self.sdf_widget.setToolTip('Instead of writing multiple databases per scenario,\n'
-                                   'write one database and a scenario difference file')
+                                   'write one database and an SDF scenario difference file')
         self.sdf_widget.setLayout(self.sdf_layout)
         self.layout.addWidget(self.sdf_widget)
 
@@ -174,14 +185,17 @@ class ScenarioChooserWidget(QtWidgets.QWidget):
         self.layout.addWidget(horizontal_line())
         self.setLayout(self.layout)
 
+        # signals
         signals.no_or_1_scenario_selected.connect(self.manage_sdf_state)
         signals.no_scenario_selected.connect(self.manage_import_button_state)
+        self.sdf_file_loc.clicked.connect(self.choose_sdf_location)
 
     def import_state(self):
 
         # convert the binary list to a list of indices that were selected
         include_scenarios = [i for i, state in enumerate(self.data_package_table.model.include) if state]
 
+        # match the dependencies (databases) of the scenarios to the correct databases in AB
         dependencies = []
         for dependency in self.data_package_table.model.data_package.descriptor['dependencies']:
             dependencies.append(dependency['name'])
@@ -189,15 +203,29 @@ class ScenarioChooserWidget(QtWidgets.QWidget):
         if not dependencies:
             return
 
+        # read/set the correct data for SDF
+        as_sdf = self.sdf_check.isChecked()
         sdf_db = self.sdf_name_field.text()
-        if sdf_db == '':
+        if sdf_db == '' and not as_sdf:
             sdf_db = None
+        elif sdf_db == '' and as_sdf:
+            # no name was chosen for the superstructure, generate a descriptive name
+            db = [db for db in dependencies.values() if db != 'biosphere3'][0]  # get db name
+            scn = self.data_package_table.model.scenario_name
+            sdf_db = ' - '.join([db, scn])
+        sdf_loc = self.sdf_file_loc
+        if sdf_loc == '':
+            sdf_loc = None
+
+        # start database generation
         signals.generate_db.emit(
             include_scenarios,  # List of scenario indices to include
             dependencies,  # dict of dependency names (translated between datapackage and current bw project
-            self.sdf_check.isChecked(),  # whether to make this into superstructure format
-            sdf_db  # superstructure database name (str or None)
+            as_sdf,  # whether to make this into superstructure format (bool)
+            sdf_db,  # superstructure database name (str or None)
+            sdf_loc  # superstructure SDF file location (str or None)
         )
+        self.sdf_file_loc = None
 
     def relink_database(self, depends: list) -> dict:
         """Relink technosphere exchanges within the given Fold."""
@@ -221,10 +249,18 @@ class ScenarioChooserWidget(QtWidgets.QWidget):
             self.sdf_check.setChecked(False)
         self.sdf_check.setEnabled(not state)
         self.sdf_name_field.setEnabled(not state)
+        self.sdf_file_loc.setEnabled(not state)
 
     def manage_import_button_state(self, state: bool) -> None:
         """Change import button UI elements depending on whether >=1 scenarios are selected."""
         self.import_b.setEnabled(not state)
+
+    def choose_sdf_location(self) -> None:
+        """Start dialog so user can choose location for SDF file export."""
+        path = QtWidgets.QFileDialog.getExistingDirectory(
+            caption="Select location to export SDF file to",
+        )
+        self.sdf_file_loc = path
 
 
 class RelinkDialog(DatabaseLinkingDialog):

--- a/ab_plugin_scenariolink/signals.py
+++ b/ab_plugin_scenariolink/signals.py
@@ -5,7 +5,7 @@ class Signals(QObject):
     get_datapackage_from_disk = Signal()  # Get a datapackage from disk
     record_ready = Signal(bool)  # datapackage extraction is complete and scenarios table should be shown
 
-    generate_db = Signal(list, dict, bool, object)  # Generate database from selected scenario data
+    generate_db = Signal(list, dict, bool, object, object)  # Generate database from selected scenario data
 
     no_or_1_scenario_selected = Signal(bool)  # True when no or one scenarios are selected
     no_scenario_selected = Signal(bool)  # True when no scenario is selected

--- a/ab_plugin_scenariolink/tables/models.py
+++ b/ab_plugin_scenariolink/tables/models.py
@@ -71,6 +71,7 @@ class DataPackageModel(PandasModel):
         super().__init__(parent=parent)
         self.data_package = None
         self.include = None
+        self.scenario_name = None
 
         self._connect_signals()
 
@@ -118,6 +119,13 @@ class DataPackageModel(PandasModel):
                     data[key].append(value)
                 else:
                     data[key] = [value]
+
+        name = data.get('name', [False])[0]
+        if name:
+            # this only works because we know a scenario name ends in ' - YYYY', if that changes, this fails
+            self.scenario_name = name[:-7]
+        else:
+            self.scenario_name = None
 
         self.last_include = self.include
         return pd.DataFrame(data)

--- a/ab_plugin_scenariolink/utils.py
+++ b/ab_plugin_scenariolink/utils.py
@@ -3,6 +3,7 @@ Utility functions for the ScenarioLink plugin.
 This module contains various utility functions that are used throughout the plugin.
 """
 
+from typing import Optional
 import zipfile
 import os
 import tempfile
@@ -24,7 +25,8 @@ def unfold_databases(
         scenarios: list,
         dependencies: dict,
         superstructure: bool,
-        superstructure_db_name: str) -> None:
+        superstructure_db_name: Optional[str],
+        superstructure_sdf_location: Optional[str]) -> None:
     """
     Unfold databases based on a given filepath and scenarios list.
 
@@ -33,7 +35,10 @@ def unfold_databases(
         scenarios (list): The list of scenarios to unfold.
         dependencies (dict): A dictionary containing dependencies.
         superstructure (bool): Flag to indicate if a superstructure should be unfolded.
-        superstructure_db_name
+        superstructure_db_name Optional[str]: name of the database.
+        superstructure_sdf_location Optional[str]: folder path to export the SDF file to.
+
+    Last two arguments are required if superstructure is True
 
     Returns:
         None: This function performs the unfolding operation but does not return anything.
@@ -54,7 +59,8 @@ def unfold_databases(
             dependencies=dependencies,
             scenarios=scenarios,
             superstructure=superstructure,
-            name=superstructure_db_name
+            name=superstructure_db_name,
+            export_dir=superstructure_sdf_location
         )
     except Exception as e:
         print(f"Failed to unfold database: {e}")


### PR DESCRIPTION
resolve #8, resolve #20

1. Users can now choose a folder to export their SDF, if none is chosen, `cwd` is used (unfold default).
2. Superstructure database and SDF will take the name from the name field or of none is give, be given a descriptive name (e.g. `ecoinvent 3.9.1 - image - SSP1-Base`)
3. Export button has tooltip

![image](https://github.com/polca/ScenarioLink/assets/34626062/7845e01e-225d-40e1-929f-4aa72a675ac2)
