### PR TITLE
Make ScenarioLink AB=2.10 compatible

### DIFF
--- a/ab_plugin_scenariolink/__init__.py
+++ b/ab_plugin_scenariolink/__init__.py
@@ -6,7 +6,7 @@ class Plugin(ab.Plugin):
 
     def __init__(self):
         infos = {
-            'name': "ScenarioLink",
+            "name": "ScenarioLink",
         }
         ab.Plugin.__init__(self, infos)
 

--- a/ab_plugin_scenariolink/layouts/tabs/right.py
+++ b/ab_plugin_scenariolink/layouts/tabs/right.py
@@ -4,6 +4,7 @@ import brightway2 as bw
 from typing import List, Tuple
 from unfold.unfold import clear_cache
 
+from activity_browser import log
 from activity_browser.layouts.tabs import PluginTab
 from activity_browser.ui.style import horizontal_line, header
 from activity_browser.ui.widgets.dialog import DatabaseLinkingDialog
@@ -22,7 +23,7 @@ class RightTab(PluginTab):
         self.fold_chooser = FoldChooserWidget()
         self.scenario_chooser = ScenarioChooserWidget()
 
-        self.version_label = QtWidgets.QLabel('')
+        self.version_label = QtWidgets.QLabel("")
 
         self.construct_layout()
         self.version_check()
@@ -37,7 +38,7 @@ class RightTab(PluginTab):
         self.layout.setAlignment(QtCore.Qt.AlignTop)
 
         # Header
-        self.layout.addWidget(header(self.plugin.infos['name']))
+        self.layout.addWidget(header(self.plugin.infos["name"]))
         self.layout.addWidget(horizontal_line())
 
         # Folds chooser
@@ -76,8 +77,8 @@ class RightTab(PluginTab):
     def version_check(self) -> None:
         newer, current, latest = UpdateManager.get_versions()
         if newer:
-            label = 'A newer version of ScenarioLink is available (your version: {}, the newest version: {})'\
-                .format(current, latest)
+            label = (f"A newer version of ScenarioLink is available (your version: {current}, "
+                     f"the newest version: {latest})")
             self.version_label.setText(label)
 
 
@@ -89,17 +90,17 @@ class FoldChooserWidget(QtWidgets.QWidget):
         self.custom_package_path = None
 
         # label
-        self.label = QtWidgets.QLabel('Select the datapackage you want to use')
+        self.label = QtWidgets.QLabel("Select the datapackage you want to use")
         self.layout.addWidget(self.label)
 
         # Radio buttons to choose where to get Fold from
-        self.radio_default = QtWidgets.QRadioButton('Online datapackages')
+        self.radio_default = QtWidgets.QRadioButton("Online datapackages")
         self.radio_default.setChecked(True)
-        self.radio_custom = QtWidgets.QRadioButton('Local datapackages')
-        self.clear_datapackage_cache = QtWidgets.QPushButton('Clear datapackage cache')
+        self.radio_custom = QtWidgets.QRadioButton("Local datapackages")
+        self.clear_datapackage_cache = QtWidgets.QPushButton("Clear datapackage cache")
         self.clear_datapackage_cache.setToolTip(
-            'ScenarioLink caches the downloaded datapackages, though sometimes\n'
-            'these may be updated and you need to clear the cache.'
+            "ScenarioLink caches the downloaded datapackages, though sometimes\n"
+            "these may be updated and you need to clear the cache."
         )
         self.radio_layout = QtWidgets.QHBoxLayout()
         self.radio_layout.addWidget(self.radio_default)
@@ -111,21 +112,21 @@ class FoldChooserWidget(QtWidgets.QWidget):
         self.layout.addWidget(self.radio_widget)
 
         # Folds table
-        self.table_label = QtWidgets.QLabel('Doubleclick to open a datapackage (if not present locally, it will be downloaded - this may take a while).')
+        self.table_label = QtWidgets.QLabel("Doubleclick to open a datapackage (if not present locally, it will be downloaded - this may take a while).")
         self.layout.addWidget(self.table_label)
 
         self.folds_table = FoldsTable(self)
         self.use_table = True  # bool to see if we need to read this table or instead read the local import
-        if self.folds_table.model.df_columns.get('link', False):
-            self.folds_table.setToolTip('Doubleclick to open a datapackage\n'
-                                        'Right click to open a dashboard with more information')
+        if self.folds_table.model.df_columns.get("link", False):
+            self.folds_table.setToolTip("Doubleclick to open a datapackage\n"
+                                        "Right click to open a dashboard with more information")
         else:
-            self.folds_table.setToolTip('Doubleclick to open a datapackage')
+            self.folds_table.setToolTip("Doubleclick to open a datapackage")
         self.layout.addWidget(self.folds_table)
 
         # Fold custom importer
         self.custom_layout = QtWidgets.QHBoxLayout()
-        self.custom = QtWidgets.QPushButton('Browse computer')
+        self.custom = QtWidgets.QPushButton("Browse computer")
         self.custom.setVisible(False)
         self.custom_layout.addWidget(self.custom)
         self.custom_layout.addStretch()
@@ -154,14 +155,14 @@ class FoldChooserWidget(QtWidgets.QWidget):
         """"Start a dialog to retrieve a datapackage from disk."""
         path, _ = QtWidgets.QFileDialog.getOpenFileName(
             caption="Select datapackage zip file",
-            filter='*.zip'
+            filter="*.zip"
         )
-        print('file selected from path:', path)
+        log.info(f"file selected from path: {path}")
         self.custom_package_path = path
         signals.get_datapackage_from_disk.emit(path)
 
     def do_clear_cache(self) -> None:
-        print('Clearing the datapackage cache')
+        log.info("Clearing the datapackage cache")
         clear_sl_datapackage_cache()
         self.folds_table.model.sync()
 
@@ -174,7 +175,7 @@ class ScenarioChooserWidget(QtWidgets.QWidget):
         self.sdf_path = None
 
         # Label
-        self.label = QtWidgets.QLabel('Choose the scenarios you want to install')
+        self.label = QtWidgets.QLabel("Choose the scenarios you want to install")
         self.layout.addWidget(self.label)
 
         # Datapackage table
@@ -182,14 +183,14 @@ class ScenarioChooserWidget(QtWidgets.QWidget):
         self.layout.addWidget(self.data_package_table)
 
         # SDF checker
-        self.sdf_check = QtWidgets.QCheckBox('Produce Superstructure database')
+        self.sdf_check = QtWidgets.QCheckBox("Produce Superstructure database")
         self.sdf_check.setChecked(False)
         self.sdf_check.setEnabled(False)
         self.sdf_name_field = QtWidgets.QLineEdit()
-        self.sdf_name_field.setPlaceholderText('Superstructure database name (optional)')
+        self.sdf_name_field.setPlaceholderText("Superstructure database name (optional)")
         self.sdf_name_field.setEnabled(False)
-        self.sdf_file_loc = QtWidgets.QPushButton('SDF location')
-        self.sdf_file_loc.setToolTip('Choose a folder to export the SDF scenario file to')
+        self.sdf_file_loc = QtWidgets.QPushButton("SDF location")
+        self.sdf_file_loc.setToolTip("Choose a folder to export the SDF scenario file to")
         self.sdf_file_loc.setEnabled(False)
 
         self.sdf_layout = QtWidgets.QHBoxLayout()
@@ -198,20 +199,20 @@ class ScenarioChooserWidget(QtWidgets.QWidget):
         self.sdf_layout.addWidget(self.sdf_file_loc)
         self.sdf_layout.addStretch()
         self.sdf_widget = QtWidgets.QWidget()
-        self.sdf_widget.setToolTip('Instead of writing multiple databases per scenario,\n'
-                                   'write one database and an SDF scenario difference file')
+        self.sdf_widget.setToolTip("Instead of writing multiple databases per scenario,\n""
+                                   "write one database and an SDF scenario difference file")
         self.sdf_widget.setLayout(self.sdf_layout)
         self.layout.addWidget(self.sdf_widget)
 
         # Import button
-        self.import_b = QtWidgets.QPushButton('Import')
+        self.import_b = QtWidgets.QPushButton("Import")
         self.import_b.setEnabled(False)
         self.import_layout = QtWidgets.QHBoxLayout()
         self.import_layout.addWidget(self.import_b)
         self.import_layout.addStretch()
-        self.clear_unfold_cache = QtWidgets.QPushButton('Clear unfold cache')
-        self.clear_unfold_cache.setToolTip('Unfold caches some data to work faster, though sometimes this can store old data\n'
-                                    'that should be renewed, clearing the cache allows new data to be cached.')
+        self.clear_unfold_cache = QtWidgets.QPushButton("Clear unfold cache")
+        self.clear_unfold_cache.setToolTip("Unfold caches some data to work faster, though sometimes this can store old data\n"
+                                    "that should be renewed, clearing the cache allows new data to be cached.")
         self.import_layout.addWidget(self.clear_unfold_cache)
         self.import_b_widg = QtWidgets.QWidget()
         self.import_b_widg.setLayout(self.import_layout)
@@ -228,7 +229,7 @@ class ScenarioChooserWidget(QtWidgets.QWidget):
         self.sdf_file_loc.clicked.connect(self.choose_sdf_location)
 
     def do_clear_cache(self):
-        print('Clearing the unfold cache')
+        log.info("Clearing the unfold cache")
         clear_cache()
 
     def import_state(self):
@@ -238,8 +239,8 @@ class ScenarioChooserWidget(QtWidgets.QWidget):
 
         # match the dependencies (databases) of the scenarios to the correct databases in AB
         dependencies = []
-        for dependency in self.data_package_table.model.data_package.descriptor['dependencies']:
-            dependencies.append(dependency['name'])
+        for dependency in self.data_package_table.model.data_package.descriptor["dependencies"]:
+            dependencies.append(dependency["name"])
         dependencies = self.relink_database(dependencies)
         if not dependencies:
             return
@@ -247,15 +248,15 @@ class ScenarioChooserWidget(QtWidgets.QWidget):
         # read/set the correct data for SDF
         as_sdf = self.sdf_check.isChecked()
         sdf_db = self.sdf_name_field.text()
-        if sdf_db == '' and not as_sdf:
+        if sdf_db == "" and not as_sdf:
             sdf_db = None
-        elif sdf_db == '' and as_sdf:
+        elif sdf_db == "" and as_sdf:
             # no name was chosen for the superstructure, generate a descriptive name
-            db = [db for db in dependencies.values() if db != 'biosphere3'][0]  # get db name
+            db = [db for db in dependencies.values() if db != "biosphere3"][0]  # get db name
             scn = self.data_package_table.model.scenario_name
-            sdf_db = ' - '.join([db, scn])
+            sdf_db = " - ".join([db, scn])
         sdf_loc = self.sdf_file_loc
-        if sdf_loc == '':
+        if sdf_loc == "":
             sdf_loc = None
 
         # start database generation
@@ -310,7 +311,7 @@ class RelinkDialog(DatabaseLinkingDialog):
 
     @classmethod
     def relink_scenario_link(cls, options: List[Tuple[str, List[str]]],
-                     parent=None) -> 'RelinkDialog':
+                     parent=None) -> "RelinkDialog":
         label = "Choose the ScenarioLink databases.\nBy clicking 'OK', you start the import."
         return cls.construct_dialog(label, options, parent)
 

--- a/ab_plugin_scenariolink/tables/models.py
+++ b/ab_plugin_scenariolink/tables/models.py
@@ -6,6 +6,7 @@ from urllib.error import HTTPError, URLError
 import pandas as pd
 
 from activity_browser.ui.tables.models import PandasModel
+from activity_browser import log
 from ..utils import download_files_from_zenodo, package_from_path, record_cached
 from ..signals import signals
 
@@ -43,27 +44,27 @@ class FoldsModel(PandasModel):
             dataframe = pd.read_csv(url + "?nocache", header=0, sep=";", dtype=str)
 
             cached = []
-            rec_col = dataframe.columns.tolist().index('Zenodo record ID')
+            rec_col = dataframe.columns.tolist().index("Zenodo record ID")
             for idx, row in dataframe.iterrows():
                 record_id = row.values.tolist()[rec_col]
                 cached.append(record_cached(record_id))
-            dataframe['downloaded'] = cached
+            dataframe["downloaded"] = cached
 
             self._dataframe = dataframe
         except (HTTPError, URLError) as exception:
-            print('++Failed to import data:', exception)
+            log.error(f"Failed to import data: {exception}")
 
         self.df_columns = {n: i for i, n in enumerate(dataframe.columns.tolist())}
         self.updated.emit()
 
     def get_record(self, idx):
         """Retrieve a record from a selected row in the DataFrame."""
-        record = self._dataframe.iat[idx.row(), self.df_columns['Zenodo record ID']]
+        record = self._dataframe.iat[idx.row(), self.df_columns["Zenodo record ID"]]
         self.selected_record = record
         return record
 
     def get_link(self, row: int) -> str:
-        return self._dataframe.iloc[row, self.df_columns['link']]
+        return self._dataframe.iloc[row, self.df_columns["link"]]
 
     def record_ready(self, ready: bool) -> None:
         if ready:
@@ -100,8 +101,8 @@ class DataPackageModel(PandasModel):
             return
 
         datapackage = self.data_package
-        dataframe = self.build_df_from_descriptor(datapackage.descriptor['scenarios'])
-        dataframe = dataframe.reindex(columns=['include', 'name', 'description'])
+        dataframe = self.build_df_from_descriptor(datapackage.descriptor["scenarios"])
+        dataframe = dataframe.reindex(columns=["include", "name", "description"])
 
         self._dataframe = dataframe
         self.updated.emit()
@@ -122,7 +123,7 @@ class DataPackageModel(PandasModel):
             if len(self.include) <= 1:
                 signals.no_or_1_scenario_selected.emit(True)
 
-        data = {'include': self.include}
+        data = {"include": self.include}
 
         for dict_ in descr:
             for key, value in dict_.items():
@@ -131,7 +132,7 @@ class DataPackageModel(PandasModel):
                 else:
                     data[key] = [value]
 
-        name = data.get('name', [False])[0]
+        name = data.get("name", [False])[0]
         if name:
             # this only works because we know a scenario name ends in ' - YYYY', if that changes, this fails
             self.scenario_name = name[:-7]

--- a/ab_plugin_scenariolink/tables/models.py
+++ b/ab_plugin_scenariolink/tables/models.py
@@ -2,13 +2,15 @@
 This module contains the models for the tables used in the ScenarioLink plugin.
 """
 
+from logging import getLogger
 from urllib.error import HTTPError, URLError
 import pandas as pd
 
 from activity_browser.ui.tables.models import PandasModel
-from activity_browser import log
 from ..utils import download_files_from_zenodo, package_from_path, record_cached
 from ..signals import signals
+
+log = getLogger(__name__)
 
 
 class FoldsModel(PandasModel):

--- a/ab_plugin_scenariolink/tables/tables.py
+++ b/ab_plugin_scenariolink/tables/tables.py
@@ -24,8 +24,8 @@ class FoldsTable(ABDataFrameView):
     def __init__(self, parent=None):
         """Initialize the FoldsTable."""
         super().__init__(parent)
-        self.vis_columns = ['generator', 'generator version', 'creation date', 'scope',
-                            'model', 'scenario', 'source database', 'downloaded']
+        self.vis_columns = ["generator", "generator version", "creation date", "scope",
+                            "model", "scenario", "source database", "downloaded"]
 
         # Hide the vertical header and set the selection mode
         self.verticalHeader().setVisible(False)
@@ -43,7 +43,7 @@ class FoldsTable(ABDataFrameView):
         self.model.sync()
 
         # Specify the column index for the 'cached column' checkbox
-        self.cached_col = self.model.df_columns['downloaded']
+        self.cached_col = self.model.df_columns["downloaded"]
         self.setItemDelegateForColumn(self.cached_col, CheckboxDelegate(self))
 
         # only show the columns in self.vis_columns and present in the dataframe
@@ -62,13 +62,13 @@ class FoldsTable(ABDataFrameView):
         """
         if self.indexAt(event.pos()).row() == -1:
             return
-        if not self.model.df_columns.get('link', False):
+        if not self.model.df_columns.get("link", False):
             # the CSV with scenarios does not have a link
             return
 
         action = QtWidgets.QAction("Open dashboard in browser")
         action.triggered.connect(self.open_link)
-        action.setToolTip('Open a dashboard with more information about this scenario in the browser')
+        action.setToolTip("Open a dashboard with more information about this scenario in the browser")
         menu = QtWidgets.QMenu(self)
         menu.addAction(action)
         menu.exec_(event.globalPos())

--- a/ab_plugin_scenariolink/tables/tables.py
+++ b/ab_plugin_scenariolink/tables/tables.py
@@ -55,7 +55,6 @@ class FoldsTable(ABDataFrameView):
         """Connect signals to slots."""
         self.doubleClicked.connect(self.row_selected)
         self.model.updated.connect(self.update_proxy_model)
-        self.model.updated.connect(self.custom_view_sizing)
         self.model.updated.connect(self.update_col_width)
 
     def contextMenuEvent(self, event: QContextMenuEvent) -> None:
@@ -117,7 +116,6 @@ class DataPackageTable(ABDataFrameView):
     def _connect_signals(self):
         """Connect signals to slots."""
         self.model.updated.connect(self.update_proxy_model)
-        self.model.updated.connect(self.custom_view_sizing)
         self.model.updated.connect(lambda: signals.record_ready.emit(True))
         self.model.updated.connect(self.update_col_width)
 

--- a/ab_plugin_scenariolink/utils.py
+++ b/ab_plugin_scenariolink/utils.py
@@ -17,12 +17,14 @@ from importlib.metadata import version, PackageNotFoundError
 from typing import Tuple
 from tqdm import tqdm
 import hashlib
+from logging import getLogger
 
 from PySide2 import QtWidgets
 from PySide2.QtWidgets import QApplication
 from PySide2.QtCore import Qt
 
-from activity_browser import log
+
+log = getLogger(__name__)
 
 
 def unfold_databases(

--- a/ab_plugin_scenariolink/utils.py
+++ b/ab_plugin_scenariolink/utils.py
@@ -22,6 +22,8 @@ from PySide2 import QtWidgets
 from PySide2.QtWidgets import QApplication
 from PySide2.QtCore import Qt
 
+from activity_browser import log
+
 
 def unfold_databases(
         file: str,
@@ -49,7 +51,7 @@ def unfold_databases(
 
     if not os.path.exists(file):
         # we only received a recordID (not a valid path), convert to path
-        cache_folder = appdirs.user_cache_dir('ActivityBrowser', 'ActivityBrowser')
+        cache_folder = appdirs.user_cache_dir("ActivityBrowser", "ActivityBrowser")
         filename = f"{file}.zip"
         filepath = os.path.join(cache_folder, os.path.basename(filename))
     else:
@@ -68,25 +70,25 @@ def unfold_databases(
             export_dir=superstructure_sdf_location
         )
     except Exception as e:
-        print(f"Failed to unfold database: {e}")
+        log.error(f"Failed to unfold database: {e}")
         return
 
 def download_file_with_progress(file_url, output_path):
     # Function to download a file with a progress bar
     with requests.get(file_url, stream=True, timeout=100, allow_redirects=True) as response:
         response.raise_for_status()
-        total_size = int(response.headers.get('content-length', 0))
+        total_size = int(response.headers.get("content-length", 0))
         block_size = 1024  # Adjust the block size as needed
 
         with tqdm(
                 total=total_size,
-                unit='B',
+                unit="B",
                 unit_scale=True,
                 unit_divisor=block_size,
                 dynamic_ncols=True,  # Allow dynamic resizing of the progress bar
                 desc=os.path.basename(output_path),
         ) as progress_bar:
-            with open(output_path, 'wb') as file:
+            with open(output_path, "wb") as file:
                 for data in response.iter_content(block_size):
                     progress_bar.update(len(data))
                     file.write(data)
@@ -105,7 +107,7 @@ def verify_file_integrity(file_path, expected_hash):
 
         return file_hash.hexdigest() == expected_hash
     except Exception as e:
-        print(f"Error verifying file integrity: {e}")
+        log.error(f"Error verifying file integrity: {e}")
         return False
 
 def download_files_from_zenodo(record_id: str) -> [Package, None]:
@@ -134,27 +136,27 @@ def download_files_from_zenodo(record_id: str) -> [Package, None]:
     url = f"https://zenodo.org/api/records/{record_id}/files"
 
     # Create a folder to save the downloaded files
-    folder_name = appdirs.user_cache_dir('ActivityBrowser', 'ActivityBrowser')
+    folder_name = appdirs.user_cache_dir("ActivityBrowser", "ActivityBrowser")
     if not os.path.exists(folder_name):
         os.makedirs(folder_name)
 
-    print("Cache folder: ", folder_name)
+    log.info(f"Cache folder: {folder_name}")
 
     # Define the ZIP filename based on the Zenodo record ID
     zip_filename = f"{record_id}.zip"
 
     # Check if the file already exists; if so, return the Package
     if record_cached(record_id):
-        print(f"File {zip_filename} already exists in cache.")
+        log.info(f"File {zip_filename} already exists in cache.")
         return Package(os.path.join(folder_name, zip_filename))
 
-    print(f"Fetching data from Zenodo: {url}")
+    log.info(f"Fetching data from Zenodo: {url}")
 
     # Perform GET request to fetch the raw JSON content
     try:
         response = requests.get(url, timeout=100)
     except Exception as e:
-        print(f"Failed to get data from Zenodo. Error: {e}")
+        log.error(f"Failed to get data from Zenodo. Error: {e}")
         return retry_dialog()
 
     json_data = response.json()
@@ -163,9 +165,9 @@ def download_files_from_zenodo(record_id: str) -> [Package, None]:
     QApplication.setOverrideCursor(Qt.WaitCursor)
 
     # Create a final ZIP file to store the downloaded files
-    with zipfile.ZipFile(os.path.join(folder_name, zip_filename), 'w') as final_zip:
-        for idx, file_info in enumerate(json_data['entries']):
-            print(f"Downloading file {idx + 1}/{len(json_data['entries'])}")
+    with zipfile.ZipFile(os.path.join(folder_name, zip_filename), "w") as final_zip:
+        for idx, file_info in enumerate(json_data["entries"]):
+            log.info(f"Downloading file {idx + 1}/{len(json_data['entries'])}")
             file_url = f"{file_info['links']['content']}"
             download_tmpdirname = tempfile.TemporaryDirectory().name
             # Create a temporary directory to store the downloaded ZIP file
@@ -175,27 +177,27 @@ def download_files_from_zenodo(record_id: str) -> [Package, None]:
             try:
                 download_file_with_progress(file_url, downloaded_zip_path)
             except Exception as e:
-                print(f'Download failed {e}')
+                log.error(f"Download failed {e}")
                 return retry_dialog()
 
             # Verify the integrity of the downloaded file
             # fetch the MD5 hash from the JSON
-            expected_hash = file_info['checksum'][4:]
+            expected_hash = file_info["checksum"][4:]
 
             if verify_file_integrity(downloaded_zip_path, expected_hash):
-                print(f"File {idx + 1} verified successfully.")
+                log.info(f"File {idx + 1} verified successfully.")
             else:
-                print(f"File {idx + 1} verification failed. Deleting {downloaded_zip_path}.")
+                log.warning(f"File {idx + 1} verification failed. Deleting {downloaded_zip_path}.")
                 # Delete the temporary and final files if the hash doesn't match
                 os.remove(downloaded_zip_path)
                 os.remove(os.path.join(folder_name, zip_filename))
-                print("File verification failed.")
+                log.warning("File verification failed.")
                 return retry_dialog()
 
             # Create another temporary directory for the extracted files
             with tempfile.TemporaryDirectory() as extract_tmpdirname:
                 # Extract the ZIP file's contents
-                with zipfile.ZipFile(downloaded_zip_path, 'r') as downloaded_zip:
+                with zipfile.ZipFile(downloaded_zip_path, "r") as downloaded_zip:
                     downloaded_zip.extractall(extract_tmpdirname)
 
                 # Add the extracted files to the final ZIP file
@@ -205,7 +207,7 @@ def download_files_from_zenodo(record_id: str) -> [Package, None]:
                         relative_path = os.path.relpath(os.path.join(root, file), extract_tmpdirname)
                         # Add the file to the ZIP archive with its relative path
                         final_zip.write(os.path.join(root, file), relative_path)
-        print("Done.")
+        log.info("Done.")
     # Restore the original cursor
     QApplication.restoreOverrideCursor()
 
@@ -213,23 +215,23 @@ def download_files_from_zenodo(record_id: str) -> [Package, None]:
 
 def package_from_path(path: str) -> [Package, None]:
     """Create a package from the selected zip file"""
-    if not path.endswith('.zip'):
-        print("Error, file selected is not a .zip file.")
+    if not path.endswith(".zip"):
+        log.error("Error, file selected is not a .zip file.")
         return
     return Package(path)
 
 def record_cached(record: str) -> bool:
     """Return if record is cached."""
-    folder_name = appdirs.user_cache_dir('ActivityBrowser', 'ActivityBrowser')
+    folder_name = appdirs.user_cache_dir("ActivityBrowser", "ActivityBrowser")
     if not os.path.exists(folder_name):
         os.makedirs(folder_name)
 
-    zip_filename = record + '.zip'
+    zip_filename = record + ".zip"
     return os.path.exists(os.path.join(folder_name, zip_filename))
 
 def clear_sl_datapackage_cache() -> None:
     """Clear all datapackages from the ScenarioLink cache"""
-    folder_name = appdirs.user_cache_dir('ActivityBrowser', 'ActivityBrowser')
+    folder_name = appdirs.user_cache_dir("ActivityBrowser", "ActivityBrowser")
     if not os.path.exists(folder_name):
         # the cache folder does not exist, so nothing to clear
         return
@@ -254,7 +256,7 @@ class UpdateManager():
         current = cls._current_version(cls)
         latest = cls._fetch_latest(cls)
 
-        for c, l in zip(current.split('.'), latest.split('.')):
+        for c, l in zip(current.split("."), latest.split(".")):
             if int(l) > int(c):
                 return (True, current, latest)
         return (False, current, latest)
@@ -262,12 +264,13 @@ class UpdateManager():
     def _fetch_latest(self) -> str:
         """Fetch the latest version number from conda channel."""
         try:
-            package_url = 'https://anaconda.org/romainsacchi/ab-plugin-scenariolink/labels'
-            page = requests.get(package_url)  # retrieve the page from the URL
+            package_url = "https://anaconda.org/romainsacchi/ab-plugin-scenariolink/labels"
+            page = requests.get(package_url, timeout=3)  # retrieve the page from the URL
             df = pd.read_html(io.StringIO(page.text))[0]  # read the version table from the HTML
             latest = df.iloc[0, 1]
-        except:  # TODO log error properly and handle it properly
-            latest = '0.0.0'
+        except Exception as e:
+            log.debug(f"Could not retrieve latest plugin version with error: {e}")
+            latest = "0.0.0"
         return latest
 
     def _current_version(self) -> str:

--- a/ci/recipe/stable/meta.yaml
+++ b/ci/recipe/stable/meta.yaml
@@ -19,12 +19,13 @@ build:
 
 requirements:
   build:
-    - python
-    - setuptools
+    - activity-browser >=2.10.1
     - conda-verify
-    - unfold >=2024.05.14
     - datapackage
     - pandas
+    - python
+    - setuptools
+    - unfold >=2024.05.14
   run:
     - activity-browser
     - unfold

--- a/ci/recipe/stable/meta.yaml
+++ b/ci/recipe/stable/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-    - activity-browser >=2.10.1
+    - activity-browser >2.10.0
     - conda-verify
     - datapackage
     - pandas

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@ accepted_filetypes = (".html", ".png", ".svg", ".js", ".css")
 
 for dirpath, dirnames, filenames in os.walk("ab_plugin_scenariolink"):
     # Ignore dirnames that start with '.'
-    if ('__init__.py' in filenames
+    if ("__init__.py" in filenames
             or any(x.endswith(accepted_filetypes) for x in filenames)):
-        pkg = dirpath.replace(os.path.sep, '.')
+        pkg = dirpath.replace(os.path.sep, ".")
         if os.path.altsep:
-            pkg = pkg.replace(os.path.altsep, '.')
+            pkg = pkg.replace(os.path.altsep, ".")
         packages.append(pkg)
 
 setup(
@@ -24,7 +24,7 @@ setup(
     include_package_data=True,
     author="Romain Sacchi, Marc van der Meide",
     author_email="romain.sacchi@psi.ch, m.t.van.der.meide@cml.leidenuniv.nl",
-    license=open('LICENSE.txt').read(),
+    license=open("LICENSE.txt").read(),
     install_requires=[
         "activity-browser >=2.9.7, <2.10",
         "unfold >=1.2.0",
@@ -33,6 +33,6 @@ setup(
         "tqdm"
     ],
     url="https://github.com/polca/ScenarioLink",
-    long_description=open('README.md').read(),
+    long_description=open("README.md").read(),
     description="Activity Browser plugin to download scenario-based LCA databases ",
     )


### PR DESCRIPTION
- Fix compatibility issues with AB
- Set minimum AB version of `2.10.1`
  - This should allow older versions of SL to still be installed with older AB versions
  - AB `2.10.1` is [not released yet](https://github.com/LCA-ActivityBrowser/activity-browser/milestone/17) but once released, this version should install when the correct version of AB is available
- Replace all prints with AB logger
- Standardize all string quotes to `"` for consistency
- Log error handling with plugin version retrieval 