### PR TITLE
Only try to create a new release when a new tag is pushed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: stable release
-on: [push, pull_request]
+on:
+  push:
+    tags:
+      - '*'
 
 jobs:
   release:


### PR DESCRIPTION
Only try to create a new release when a new tag is pushed

Previously GH actions tried to create a new release when pushing to any branch or merging a PR, this should instead happen when a new tag is pushed.


